### PR TITLE
added support and a lazy migration strategy from cookies to localStorage

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -44,7 +44,7 @@ define(function() {
 			// cookie in the process.
 			settings_ = value;
 			writeSettings(value);
-			document.cookie = SETTINGS_KEY + '==; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+			document.cookie = SETTINGS_KEY + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
 			return value;
 		})[0];
 	}


### PR DESCRIPTION
Move from cookies to web storage because it prevents passive API token theft. I've tried to keep my code compatibility roughly the same as the original (though that was probably needlessly conservative since it's 5 years later 😅).

Addresses #4 